### PR TITLE
Add environment variable support to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A pre-commit hook that validates JSON files contain valid `$schema` references a
 - `--strict` flag to make missing `$schema` fail validation
 - Exits with non-zero code on errors but checks all files before exiting
 - Integrates with pre-commit hooks
+- Supports validating JSON files against a schema specified by the `$schema` key.
+- **NEW:** If the `$schema` key is missing, you can set the `JSON_SCHEMA_URL` environment variable to provide a default schema reference for validation.
 
 ## Installation
 
@@ -68,6 +70,13 @@ pre-commit install
 
 # Run only this specific hook
 pre-commit run [--all-files] check-json-schema-meta
+```
+
+If your JSON files do not include a `$schema` key, you can set the environment variable `JSON_SCHEMA_URL` to specify a default schema to use for validation:
+
+```bash
+export JSON_SCHEMA_URL="https://example.com/your-default-schema.json"
+pre-commit run --all-files
 ```
 
 ### Direct Usage

--- a/check_json_schema_meta.py
+++ b/check_json_schema_meta.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import jsonschema
 from check_jsonschema.schema_loader import SchemaLoader
+import os
 
 
 def validate_json_file(file_path: Path, strict: bool = False) -> bool:
@@ -35,11 +36,14 @@ def validate_json_file(file_path: Path, strict: bool = False) -> bool:
 
         schema_ref = data.get("$schema")
         if not schema_ref:
-            if strict:
-                print(f"❌ {file_path}: Missing '$schema' key")
-                return False
-            else:
-                return True
+            # Support environment variable as fallback
+            schema_ref = os.environ.get("JSON_SCHEMA_URL")
+            if not schema_ref:
+                if strict:
+                    print(f"❌ {file_path}: Missing '$schema' key and JSON_SCHEMA_URL environment variable")
+                    return False
+                else:
+                    return True
 
         # Load and validate the schema using SchemaLoader's built-in validator
         schema_loader = SchemaLoader(schema_ref)

--- a/check_json_schema_meta.py
+++ b/check_json_schema_meta.py
@@ -3,12 +3,12 @@
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
 import jsonschema
 from check_jsonschema.schema_loader import SchemaLoader
-import os
 
 
 def validate_json_file(file_path: Path, strict: bool = False) -> bool:
@@ -40,7 +40,9 @@ def validate_json_file(file_path: Path, strict: bool = False) -> bool:
             schema_ref = os.environ.get("JSON_SCHEMA_URL")
             if not schema_ref:
                 if strict:
-                    print(f"❌ {file_path}: Missing '$schema' key and JSON_SCHEMA_URL environment variable")
+                    print(
+                        f"❌ {file_path}: Missing '$schema' key and JSON_SCHEMA_URL environment variable"
+                    )
                     return False
                 else:
                     return True


### PR DESCRIPTION
Add support for `JSON_SCHEMA_URL` environment variable as a fallback for the `$schema` key.

---

[Open in Web](https://cursor.com/agents?id=bc-ac94c276-1fe3-4870-be54-6c3e527600a0) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-ac94c276-1fe3-4870-be54-6c3e527600a0) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)