### PR TITLE
feat: Support environment variables in $schema

### DIFF
--- a/check_json_schema_meta.py
+++ b/check_json_schema_meta.py
@@ -3,6 +3,7 @@
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -40,6 +41,9 @@ def validate_json_file(file_path: Path, strict: bool = False) -> bool:
                 return False
             else:
                 return True
+
+        # Expand environment variables in the schema reference
+        schema_ref = os.path.expandvars(schema_ref)
 
         # Load and validate the schema using SchemaLoader's built-in validator
         schema_loader = SchemaLoader(schema_ref)


### PR DESCRIPTION
This change adds support for environment variables in the `$schema` key of JSON files. The `os.path.expandvars` function is used to expand any environment variables found in the schema path before validation.